### PR TITLE
feat: support redis username

### DIFF
--- a/v1/backends/redis/goredis.go
+++ b/v1/backends/redis/goredis.go
@@ -37,17 +37,27 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Backend {
 	b := &BackendGR{
 		Backend: common.NewBackend(cnf),
 	}
+	var password string
+	var username string
 	parts := strings.Split(addrs[0], "@")
 	if len(parts) >= 2 {
-		// with passwrod
-		b.password = strings.Join(parts[:len(parts)-1], "@")
+		// with password
+		options := strings.SplitN(strings.Join(parts[:len(parts)-1], "@"), ":", 2)
+		if len(options) >= 2 {
+			username = options[0]
+			password = options[1]
+		} else {
+			password = options[0]
+		}
+
 		addrs[0] = parts[len(parts)-1] // addr is the last one without @
 	}
 
 	ropt := &redis.UniversalOptions{
 		Addrs:    addrs,
 		DB:       db,
-		Password: b.password,
+		Password: password,
+		Username: username,
 	}
 	if cnf.Redis != nil {
 		ropt.MasterName = cnf.Redis.MasterName

--- a/v1/backends/redis/redis.go
+++ b/v1/backends/redis/redis.go
@@ -22,6 +22,7 @@ import (
 type Backend struct {
 	common.Backend
 	host     string
+	username string
 	password string
 	db       int
 	pool     *redis.Pool
@@ -33,11 +34,12 @@ type Backend struct {
 }
 
 // New creates Backend instance
-func New(cnf *config.Config, host, password, socketPath string, db int) iface.Backend {
+func New(cnf *config.Config, host, username, password, socketPath string, db int) iface.Backend {
 	return &Backend{
 		Backend:    common.NewBackend(cnf),
 		host:       host,
 		db:         db,
+		username:   username,
 		password:   password,
 		socketPath: socketPath,
 	}
@@ -347,7 +349,7 @@ func (b *Backend) getExpiration() time.Duration {
 // open returns or creates instance of Redis connection
 func (b *Backend) open() redis.Conn {
 	b.redisOnce.Do(func() {
-		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db, b.GetConfig().Redis, b.GetConfig().TLSConfig)
+		b.pool = b.NewPool(b.socketPath, b.host, b.username, b.password, b.db, b.GetConfig().Redis, b.GetConfig().TLSConfig)
 		b.redsync = redsync.New(redsyncredis.NewPool(b.pool))
 	})
 	return b.pool.Get()

--- a/v1/brokers/redis/goredis.go
+++ b/v1/brokers/redis/goredis.go
@@ -41,10 +41,18 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Broker {
 	b := &BrokerGR{Broker: common.NewBroker(cnf)}
 
 	var password string
+	var username string
 	parts := strings.Split(addrs[0], "@")
 	if len(parts) >= 2 {
 		// with password
-		password = strings.Join(parts[:len(parts)-1], "@")
+		options := strings.SplitN(strings.Join(parts[:len(parts)-1], "@"), ":", 2)
+		if len(options) >= 2 {
+			username = options[0]
+			password = options[1]
+		} else {
+			password = options[0]
+		}
+
 		addrs[0] = parts[len(parts)-1] // addr is the last one without @
 	}
 
@@ -52,6 +60,7 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Broker {
 		Addrs:    addrs,
 		DB:       db,
 		Password: password,
+		Username: username,
 	}
 	if cnf.Redis != nil {
 		ropt.MasterName = cnf.Redis.MasterName

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -28,6 +28,7 @@ const defaultRedisDelayedTasksKey = "delayed_tasks"
 type Broker struct {
 	common.Broker
 	common.RedisConnector
+	username     string
 	host         string
 	password     string
 	db           int
@@ -43,10 +44,11 @@ type Broker struct {
 }
 
 // New creates new Broker instance
-func New(cnf *config.Config, host, password, socketPath string, db int) iface.Broker {
+func New(cnf *config.Config, host, username, password, socketPath string, db int) iface.Broker {
 	b := &Broker{Broker: common.NewBroker(cnf)}
 	b.host = host
 	b.db = db
+	b.username = username
 	b.password = password
 	b.socketPath = socketPath
 
@@ -475,7 +477,7 @@ func (b *Broker) nextDelayedTask(key string) (result []byte, err error) {
 // open returns or creates instance of Redis connection
 func (b *Broker) open() redis.Conn {
 	b.redisOnce.Do(func() {
-		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db, b.GetConfig().Redis, b.GetConfig().TLSConfig)
+		b.pool = b.NewPool(b.socketPath, b.host, b.username, b.password, b.db, b.GetConfig().Redis, b.GetConfig().TLSConfig)
 		b.redsync = redsync.New(redsyncredis.NewPool(b.pool))
 	})
 

--- a/v2/backends/redis/goredis.go
+++ b/v2/backends/redis/goredis.go
@@ -37,17 +37,27 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Backend {
 	b := &BackendGR{
 		Backend: common.NewBackend(cnf),
 	}
+	var password string
+	var username string
 	parts := strings.Split(addrs[0], "@")
 	if len(parts) >= 2 {
-		// with passwrod
-		b.password = strings.Join(parts[:len(parts)-1], "@")
+		// with password
+		options := strings.SplitN(strings.Join(parts[:len(parts)-1], "@"), ":", 2)
+		if len(options) >= 2 {
+			username = options[0]
+			password = options[1]
+		} else {
+			password = options[0]
+		}
+
 		addrs[0] = parts[len(parts)-1] // addr is the last one without @
 	}
 
 	ropt := &redis.UniversalOptions{
 		Addrs:    addrs,
 		DB:       db,
-		Password: b.password,
+		Username: username,
+		Password: password,
 	}
 	if cnf.Redis != nil {
 		ropt.MasterName = cnf.Redis.MasterName

--- a/v2/backends/redis/redis.go
+++ b/v2/backends/redis/redis.go
@@ -22,6 +22,7 @@ import (
 type Backend struct {
 	common.Backend
 	host     string
+	username string
 	password string
 	db       int
 	pool     *redis.Pool
@@ -33,11 +34,12 @@ type Backend struct {
 }
 
 // New creates Backend instance
-func New(cnf *config.Config, host, password, socketPath string, db int) iface.Backend {
+func New(cnf *config.Config, host, username, password, socketPath string, db int) iface.Backend {
 	return &Backend{
 		Backend:    common.NewBackend(cnf),
 		host:       host,
 		db:         db,
+		username:   username,
 		password:   password,
 		socketPath: socketPath,
 	}
@@ -347,7 +349,7 @@ func (b *Backend) getExpiration() time.Duration {
 // open returns or creates instance of Redis connection
 func (b *Backend) open() redis.Conn {
 	b.redisOnce.Do(func() {
-		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db, b.GetConfig().Redis, b.GetConfig().TLSConfig)
+		b.pool = b.NewPool(b.socketPath, b.host, b.username, b.password, b.db, b.GetConfig().Redis, b.GetConfig().TLSConfig)
 		b.redsync = redsync.New(redsyncredis.NewPool(b.pool))
 	})
 	return b.pool.Get()

--- a/v2/backends/redis/redis_test.go
+++ b/v2/backends/redis/redis_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestGroupCompleted(t *testing.T) {
 	redisURL := os.Getenv("REDIS_URL")
+	redisUsername := os.Getenv("REDIS_USER")
 	redisPassword := os.Getenv("REDIS_PASSWORD")
 	if redisURL == "" {
 		t.Skip("REDIS_URL is not defined")
@@ -27,7 +28,7 @@ func TestGroupCompleted(t *testing.T) {
 		GroupUUID: groupUUID,
 	}
 
-	backend := redis.New(new(config.Config), redisURL, redisPassword, "", 0)
+	backend := redis.New(new(config.Config), redisURL, redisUsername, redisPassword, "", 0)
 
 	// Cleanup before the test
 	backend.PurgeState(task1.UUID)
@@ -72,6 +73,7 @@ func TestGroupCompleted(t *testing.T) {
 
 func TestGetState(t *testing.T) {
 	redisURL := os.Getenv("REDIS_URL")
+	redisUsername := os.Getenv("REDIS_USER")
 	redisPassword := os.Getenv("REDIS_PASSWORD")
 	if redisURL == "" {
 		return
@@ -82,7 +84,7 @@ func TestGetState(t *testing.T) {
 		GroupUUID: "testGroupUUID",
 	}
 
-	backend := redis.New(new(config.Config), redisURL, redisPassword, "", 0)
+	backend := redis.New(new(config.Config), redisURL, redisUsername, redisPassword, "", 0)
 
 	backend.PurgeState("testTaskUUID")
 
@@ -133,6 +135,7 @@ func TestGetState(t *testing.T) {
 
 func TestPurgeState(t *testing.T) {
 	redisURL := os.Getenv("REDIS_URL")
+	redisUsername := os.Getenv("REDIS_USER")
 	redisPassword := os.Getenv("REDIS_PASSWORD")
 	if redisURL == "" {
 		return
@@ -143,7 +146,7 @@ func TestPurgeState(t *testing.T) {
 		GroupUUID: "testGroupUUID",
 	}
 
-	backend := redis.New(new(config.Config), redisURL, redisPassword, "", 0)
+	backend := redis.New(new(config.Config), redisURL, redisUsername, redisPassword, "", 0)
 
 	backend.SetStatePending(signature)
 	taskState, err := backend.GetState(signature.UUID)

--- a/v2/brokers/redis/goredis.go
+++ b/v2/brokers/redis/goredis.go
@@ -41,10 +41,18 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Broker {
 	b := &BrokerGR{Broker: common.NewBroker(cnf)}
 
 	var password string
+	var username string
 	parts := strings.Split(addrs[0], "@")
 	if len(parts) >= 2 {
 		// with password
-		password = strings.Join(parts[:len(parts)-1], "@")
+		options := strings.SplitN(strings.Join(parts[:len(parts)-1], "@"), ":", 2)
+		if len(options) >= 2 {
+			username = options[0]
+			password = options[1]
+		} else {
+			password = options[0]
+		}
+
 		addrs[0] = parts[len(parts)-1] // addr is the last one without @
 	}
 
@@ -52,6 +60,7 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Broker {
 		Addrs:    addrs,
 		DB:       db,
 		Password: password,
+		Username: username,
 	}
 	if cnf.Redis != nil {
 		ropt.MasterName = cnf.Redis.MasterName

--- a/v2/brokers/redis/redis.go
+++ b/v2/brokers/redis/redis.go
@@ -29,6 +29,7 @@ type Broker struct {
 	common.Broker
 	common.RedisConnector
 	host         string
+	username     string
 	password     string
 	db           int
 	pool         *redis.Pool
@@ -43,10 +44,11 @@ type Broker struct {
 }
 
 // New creates new Broker instance
-func New(cnf *config.Config, host, password, socketPath string, db int) iface.Broker {
+func New(cnf *config.Config, host, username, password, socketPath string, db int) iface.Broker {
 	b := &Broker{Broker: common.NewBroker(cnf)}
 	b.host = host
 	b.db = db
+	b.username = username
 	b.password = password
 	b.socketPath = socketPath
 
@@ -475,7 +477,7 @@ func (b *Broker) nextDelayedTask(key string) (result []byte, err error) {
 // open returns or creates instance of Redis connection
 func (b *Broker) open() redis.Conn {
 	b.redisOnce.Do(func() {
-		b.pool = b.NewPool(b.socketPath, b.host, b.password, b.db, b.GetConfig().Redis, b.GetConfig().TLSConfig)
+		b.pool = b.NewPool(b.socketPath, b.host, b.username, b.password, b.db, b.GetConfig().Redis, b.GetConfig().TLSConfig)
 		b.redsync = redsync.New(redsyncredis.NewPool(b.pool))
 	})
 

--- a/v2/common/redis.go
+++ b/v2/common/redis.go
@@ -27,7 +27,7 @@ var (
 type RedisConnector struct{}
 
 // NewPool returns a new pool of Redis connections
-func (rc *RedisConnector) NewPool(socketPath, host, password string, db int, cnf *config.RedisConfig, tlsConfig *tls.Config) *redis.Pool {
+func (rc *RedisConnector) NewPool(socketPath, host, username, password string, db int, cnf *config.RedisConfig, tlsConfig *tls.Config) *redis.Pool {
 	if cnf == nil {
 		cnf = defaultConfig
 	}
@@ -37,7 +37,7 @@ func (rc *RedisConnector) NewPool(socketPath, host, password string, db int, cnf
 		MaxActive:   cnf.MaxActive,
 		Wait:        cnf.Wait,
 		Dial: func() (redis.Conn, error) {
-			c, err := rc.open(socketPath, host, password, db, cnf, tlsConfig)
+			c, err := rc.open(socketPath, host, username, password, db, cnf, tlsConfig)
 			if err != nil {
 				return nil, err
 			}
@@ -63,7 +63,7 @@ func (rc *RedisConnector) NewPool(socketPath, host, password string, db int, cnf
 }
 
 // Open a new Redis connection
-func (rc *RedisConnector) open(socketPath, host, password string, db int, cnf *config.RedisConfig, tlsConfig *tls.Config) (redis.Conn, error) {
+func (rc *RedisConnector) open(socketPath, host, username, password string, db int, cnf *config.RedisConfig, tlsConfig *tls.Config) (redis.Conn, error) {
 	var opts = []redis.DialOption{
 		redis.DialDatabase(db),
 		redis.DialReadTimeout(time.Duration(cnf.ReadTimeout) * time.Second),
@@ -74,6 +74,9 @@ func (rc *RedisConnector) open(socketPath, host, password string, db int, cnf *c
 
 	if tlsConfig != nil {
 		opts = append(opts, redis.DialTLSConfig(tlsConfig), redis.DialUseTLS(true))
+	}
+	if username != "" {
+		opts = append(opts, redis.DialUsername(username))
 	}
 
 	if password != "" {

--- a/v2/example/redigo/main.go
+++ b/v2/example/redigo/main.go
@@ -81,8 +81,8 @@ func startServer() (*machinery.Server, error) {
 	}
 
 	// Create server instance
-	broker := redisbroker.New(cnf, "localhost:6379", "", "", 0)
-	backend := redisbackend.New(cnf, "localhost:6379", "", "", 0)
+	broker := redisbroker.New(cnf, "localhost:6379", "", "", "", 0)
+	backend := redisbackend.New(cnf, "localhost:6379", "", "", "", 0)
 	lock := eagerlock.New()
 	server := machinery.NewServer(cnf, broker, backend, lock)
 


### PR DESCRIPTION
This pull request introduces support for Redis authentication with both username and password, enhancing compatibility with Redis ACL (Access Control List) features. The changes span multiple files, updating connection logic, factory methods, and tests to handle the new username parameter alongside the existing password parameter.

### Redis Authentication Enhancements:

* Updated Redis connection logic to parse and handle both username and password from connection strings. This includes splitting credentials into `username` and `password` components when provided in the format `username:password@host`. (`v1/backends/redis/goredis.go`, `v1/brokers/redis/goredis.go`, `v2/backends/redis/goredis.go`) [[1]](diffhunk://#diff-ca961566c60918b728d7b69a3b40e249d5d48fcc65477043058f359f19f2863aR40-R60) [[2]](diffhunk://#diff-595f580fd915a71addf5d6a5cece364e0f397950243f99f4555d892f914f9745R44-R63) [[3]](diffhunk://#diff-99a53b54f57bab18c6f0dd903330763d9cf29e1fbea2d97bb489621fd2b31352R40-R60)
* Modified `RedisConnector` methods (`NewPool` and `open`) to accept and utilize the username parameter when establishing Redis connections. (`v1/common/redis.go`) [[1]](diffhunk://#diff-38f43393c404819c16aa8ca16508565289e7776c293f959b3b8b7c1ffe12fbe7L30-R30) [[2]](diffhunk://#diff-38f43393c404819c16aa8ca16508565289e7776c293f959b3b8b7c1ffe12fbe7L66-R66) [[3]](diffhunk://#diff-38f43393c404819c16aa8ca16508565289e7776c293f959b3b8b7c1ffe12fbe7R79-R82)

### Factory and Constructor Updates:

* Updated factory methods (`BackendFactory`, `BrokerFactory`) to extract and pass the username parameter from Redis URLs or socket URLs. (`v1/factories.go`) [[1]](diffhunk://#diff-f86ce481fdf2697232c73fce1d2640ce1320cb5bd91d7b7e2b901d1bc8330332L64-R78) [[2]](diffhunk://#diff-f86ce481fdf2697232c73fce1d2640ce1320cb5bd91d7b7e2b901d1bc8330332L146-R162) [[3]](diffhunk://#diff-f86ce481fdf2697232c73fce1d2640ce1320cb5bd91d7b7e2b901d1bc8330332L186-R186) [[4]](diffhunk://#diff-f86ce481fdf2697232c73fce1d2640ce1320cb5bd91d7b7e2b901d1bc8330332L248-R250)
* Adjusted constructors for `Backend` and `Broker` to include the `username` parameter. (`v1/backends/redis/redis.go`, `v1/brokers/redis/redis.go`) [[1]](diffhunk://#diff-943dca6b100fb6fda2015b753aca9e3e4238bd8f4e1834934425cc55c03d08b9L36-R42) [[2]](diffhunk://#diff-ba6dfc551533b11a2785250b44546de9abd7d41090d933643c4cf2cd6c12412cL46-R51)

### Test Suite Enhancements:

* Updated test cases to validate username handling in Redis URL parsing and connection creation. This includes adding scenarios for combinations of username, password, and host in Redis URLs and socket URLs. (`v1/factories_test.go`) [[1]](diffhunk://#diff-d9dba353acc061f099c221cd87007e6d7c2e0b002543a673bac7680ecaf61cf2L30-R30) [[2]](diffhunk://#diff-d9dba353acc061f099c221cd87007e6d7c2e0b002543a673bac7680ecaf61cf2L138-R144) [[3]](diffhunk://#diff-d9dba353acc061f099c221cd87007e6d7c2e0b002543a673bac7680ecaf61cf2L436-R478)
* Adjusted expected values in factory-related tests to account for the new username parameter in `Backend` and `Broker` instances. (`v1/factories_test.go`) [[1]](diffhunk://#diff-d9dba353acc061f099c221cd87007e6d7c2e0b002543a673bac7680ecaf61cf2L334-R340) [[2]](diffhunk://#diff-d9dba353acc061f099c221cd87007e6d7c2e0b002543a673bac7680ecaf61cf2L349-R355) [[3]](diffhunk://#diff-d9dba353acc061f099c221cd87007e6d7c2e0b002543a673bac7680ecaf61cf2L364-R370) 

These changes ensure that the project can now handle Redis connections requiring both username and password, aligning with modern Redis authentication practices.